### PR TITLE
Makefile.am: Add missing 'EXTRA_DIST' & 'ktsuss_SOURCES' files.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,4 +4,4 @@ SUBDIRS = src pixmaps
 MAINTAINERCLEANFILES = Makefile.in configure aclocal.m4 \
 			config.h config.h.in
 AUTOMAKE_OPTIONS = foreign dist-bzip2
-EXTRA_DIST = autogen.bash AUTHORS Changelog COPYING INSTALL README
+EXTRA_DIST = autogen.sh Changelog COPYING CREDITS INSTALL LICENSE README.md

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,5 @@
 bin_PROGRAMS = ktsuss
 
-ktsuss_SOURCES = ktsuss.c su_backend.c sudo_backend.c
+ktsuss_SOURCES = errors.h ktsuss.c su_backend.c su_backend.h sudo_backend.c sudo_backend.h
 ktsuss_LDADD = $(DEPS_LIBS) -lutil
 AM_CPPFLAGS = $(DEPS_CFLAGS) -DPIXMAPS=\""$(datadir)/pixmaps"\"


### PR DESCRIPTION
In 'Makefile.am' I added some missing 'EXTRA_DIST' files & in 'src/Makefile.am' added the missing 'ktsuss_SOURCES' files, which allows creation of dist packages correctly.
